### PR TITLE
Specify an id for job

### DIFF
--- a/infrastructure-tests/testing-jenkins.yml
+++ b/infrastructure-tests/testing-jenkins.yml
@@ -5,6 +5,7 @@ jobs:
       multibranchPipelineJob('validation-job') {
           branchSources {
               git {
+                  id('validation-job')
                   remote("https://github.com/piper-validation/cloud-s4-sdk-book")
                   includes('validate-cx-server')
               }


### PR DESCRIPTION
This should fix the failing jobs

Stacktrace:

```
javaposse.jobdsl.dsl.DslScriptException: (script, line 3) id must be specified
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
	at org.codehaus.groovy.reflection.CachedConstructor.invoke(CachedConstructor.java:83)
	at org.codehaus.groovy.runtime.callsite.ConstructorSite$ConstructorSiteNoUnwrapNoCoerce.callConstructor(ConstructorSite.java:105)
	at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCallConstructor(CallSiteArray.java:60)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callConstructor(AbstractCallSite.java:235)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callConstructor(AbstractCallSite.java:247)
	at javaposse.jobdsl.dsl.Preconditions.checkNotNullOrEmpty(Preconditions.groovy:68)
```