### PR TITLE
Add pipeline-github plugin

### DIFF
--- a/jenkins-master/plugins.txt
+++ b/jenkins-master/plugins.txt
@@ -30,6 +30,7 @@ nexus-artifact-uploader
 parameterized-trigger
 performance
 pipeline-build-step
+pipeline-github
 pipeline-input-step
 pipeline-milestone-step
 pipeline-stage-step


### PR DESCRIPTION
Without this plugin the piperPipeline fails with:

Invalid trigger type "issueCommentTrigger". Valid trigger types: [upstream, cron, githubPush, pollSCM]

See the trigger definition part of the piperPipeline (triggers).