### PR TITLE
Offer migration in case s4sdk/ jenkins-master image is configured

### DIFF
--- a/cx-server-companion/files/cx-server-companion.sh
+++ b/cx-server-companion/files/cx-server-companion.sh
@@ -643,6 +643,7 @@ function backup_volume()
 
     #ensure that folder exists
     mkdir -p "${backup_folder}"
+    
     # FNR will skip the header and awk will print only 4th column of the output.
     local free_space=$(df -h "${backup_folder}" | awk 'FNR > 1 {print $4}')
     local used_space=$(docker run --rm -v "${jenkins_home}":/jenkins_home_dir "${alpine_docker_image}" du -sh /jenkins_home_dir | awk '{print $1}')

--- a/cx-server-companion/files/cx-server-companion.sh
+++ b/cx-server-companion/files/cx-server-companion.sh
@@ -962,8 +962,8 @@ function migrate_s4sdk_to_ppiper_images()
 function warn_and_offer_migration()
 {
     log_warn "Since October 2019 the s4sdk/jenkins-master image is deprecated. The docker images for the SAP Cloud SDK are now maintained in the repository https://github.com/SAP/devops-docker-cx-server."
-    log_warn "This migration will stop jenkins-master, change the docker_image in server.cfg to $1, start the backup of your jenkins-home volume and finally starts jenkins-master again. Those tasks will result in a few minutes downtime."
-    read -n 1 -p "Do you want to update the configured docker_image in server.cfg to '$1'? (Y/N): " input
+    log_warn "This migration will start the backup of your jenkins-home volume, change the docker_image in server.cfg to $1, stop s4sdk/jenkins-master and finally start ppiper/jenkins-master. Those tasks will result in a few minutes of downtime."
+    read -n 1 -p "Do you want to proceed with the migration? (Y/N): " input
     echo ""
     if [[ "$input" == "y" ]] || [[ "$input" == "Y" ]]; then
         backup_volume

--- a/cx-server-companion/files/cx-server-companion.sh
+++ b/cx-server-companion/files/cx-server-companion.sh
@@ -971,16 +971,14 @@ function warn_and_offer_migration()
 
 function migrate_s4sdk_to_ppiper_image()
 {
-    if [[ ! -z "$1" ]]; then
-        backup_volume
-        sed -i "/docker_image/c\docker_image=\"$1\"" /cx-server/mount/server.cfg
-        docker stop s4sdk-jenkins-master
-        docker rm s4sdk-jenkins-master
-        remove_networks
-        read_configuration
-        start_jenkins
-        exit 0
-    fi
+    backup_volume
+    sed -i "/docker_image/c\docker_image=\"$1\"" /cx-server/mount/server.cfg
+    docker stop s4sdk-jenkins-master
+    docker rm s4sdk-jenkins-master
+    remove_networks
+    read_configuration
+    start_jenkins
+    exit 0
 }
 
 function get_ppiper_jenkins_image_for_migration()

--- a/cx-server-companion/files/cx-server-companion.sh
+++ b/cx-server-companion/files/cx-server-companion.sh
@@ -949,7 +949,7 @@ function get_port_mapping(){
 
 function migrate_s4sdk_to_ppiper_images()
 {
-    if [[ $docker_image == *"s4sdk/"* ]]; then
+    if [[ $docker_image == *"s4sdk/jenkins-master:"* ]]; then
         log_warn "You have configured a deprecated version of the jenkins-master image in the server.cfg."
         read -n 1 -p "Do you want to update the configured docker_image in server.cfg to 'ppiper/jenkins-master'? (Y/N): " input
         echo ""

--- a/cx-server-companion/files/cx-server-companion.sh
+++ b/cx-server-companion/files/cx-server-companion.sh
@@ -961,16 +961,16 @@ function migrate_s4sdk_to_ppiper_images()
 
 function warn_and_offer_migration()
 {
-    log_warn "Since October 2019 the s4sdk/jenkins-master image ist deprecated. The docker images for the SAP Cloud SDK are now maintained in the repository https://github.com/SAP/devops-docker-cx-server."
-    log_warn "This migration will stop jenkins-master, change the docker_image in server.cf to $1, start the backup of your jenkins-home volume and finally starts jenkins-master again. Those tasks will result in a downtime depending of the size of you jenkins_home volume up to a few hours."
+    log_warn "Since October 2019 the s4sdk/jenkins-master image is deprecated. The docker images for the SAP Cloud SDK are now maintained in the repository https://github.com/SAP/devops-docker-cx-server."
+    log_warn "This migration will stop jenkins-master, change the docker_image in server.cfg to $1, start the backup of your jenkins-home volume and finally starts jenkins-master again. Those tasks will result in a few minutes downtime."
     read -n 1 -p "Do you want to update the configured docker_image in server.cfg to '$1'? (Y/N): " input
     echo ""
     if [[ "$input" == "y" ]] || [[ "$input" == "Y" ]]; then
+        backup_volume
         sed -i "/docker_image/c\docker_image=\"$1\"" /cx-server/mount/server.cfg
         docker stop s4sdk-jenkins-master
         docker rm s4sdk-jenkins-master
         remove_networks
-        backup_volume
         read_configuration
         start_jenkins
     else

--- a/cx-server-companion/files/cx-server-companion.sh
+++ b/cx-server-companion/files/cx-server-companion.sh
@@ -643,7 +643,7 @@ function backup_volume()
 
     #ensure that folder exists
     mkdir -p "${backup_folder}"
-    
+
     # FNR will skip the header and awk will print only 4th column of the output.
     local free_space=$(df -h "${backup_folder}" | awk 'FNR > 1 {print $4}')
     local used_space=$(docker run --rm -v "${jenkins_home}":/jenkins_home_dir "${alpine_docker_image}" du -sh /jenkins_home_dir | awk '{print $1}')

--- a/cx-server-companion/files/cx-server-companion.sh
+++ b/cx-server-companion/files/cx-server-companion.sh
@@ -967,7 +967,7 @@ function warn_and_offer_migration()
     echo ""
     if [[ "$input" == "y" ]] || [[ "$input" == "Y" ]]; then
         sed -i "/docker_image/c\docker_image=\"$1\"" /cx-server/mount/server.cfg
-        docker stop s4sd-jenkins-master
+        docker stop s4sdk-jenkins-master
         docker rm s4sdk-jenkins-master
         remove_networks
         backup_volume

--- a/cx-server-companion/files/cx-server-companion.sh
+++ b/cx-server-companion/files/cx-server-companion.sh
@@ -954,7 +954,6 @@ function get_port_mapping(){
 function warn_and_offer_migration()
 {
     local newImage=$(get_ppiper_jenkins_image_for_migration)
-    echo $newImage
     if [[ ! -z "$newImage" ]]; then
         log_warn "Since October 2019 the s4sdk/jenkins-master image is deprecated. The docker images for the SAP Cloud SDK are now maintained in the repository https://github.com/SAP/devops-docker-cx-server."
         log_warn "This migration will start the backup of your jenkins-home volume, change the docker_image in server.cfg to $newImage, stop s4sdk/jenkins-master and finally start ppiper/jenkins-master. Those tasks will result in a few minutes of downtime."

--- a/cx-server-companion/files/cx-server-companion.sh
+++ b/cx-server-companion/files/cx-server-companion.sh
@@ -973,6 +973,7 @@ function warn_and_offer_migration()
         remove_networks
         read_configuration
         start_jenkins
+        exit 0
     else
         echo "No changes will be applied to server.cfg"
     fi

--- a/cx-server-companion/files/cx-server-companion.sh
+++ b/cx-server-companion/files/cx-server-companion.sh
@@ -947,8 +947,23 @@ function get_port_mapping(){
     return_value=$mapping
 }
 
+function migrate_s4sdk_to_ppiper_images()
+{
+    if [[ $docker_image == *"s4sdk/"* ]]; then
+        log_warn "You have configured a deprecated version of the jenkins-master image in the server.cfg."
+        read -n 1 -p "Do you want to update the configured docker_image in server.cfg to 'ppiper/jenkins-master'? (Y/N): " input
+        echo ""
+        if [[ "$input" == "y" ]] || [[ "$input" == "Y" ]]; then
+            sed -i "/docker_image/c\docker_image=\"ppiper/jenkins-master:latest\"" /cx-server/mount/server.cfg
+        else
+            echo "No changes will be made to server.cfg";
+        fi
+    fi
+}
+
 ### Start of Script
 read_configuration
+migrate_s4sdk_to_ppiper_images
 
 # ensure that docker is installed
 command -v docker > /dev/null 2>&1 || { echo >&2 "Docker does not seem to be installed. Please install docker and ensure that the docker command is included in \$PATH."; exit 1; }

--- a/cx-server-companion/files/cx-server-companion.sh
+++ b/cx-server-companion/files/cx-server-companion.sh
@@ -953,7 +953,7 @@ function migrate_s4sdk_to_ppiper_images()
         #TODO: update as soon as there is a new release
         warn_and_offer_migration "ppiper/jenkins-master:v2"
 
-    elif [[ $docker_image =~ ^s4sdk/jenkins-master:latest$ ]]; then
+    elif [[ $docker_image =~ ^s4sdk/jenkins-master:latest$ ]] || [[ $docker_image =~ ^s4sdk/jenkins-master$ ]]; then
         warn_and_offer_migration "ppiper/jenkins-master:latest"
     fi
 

--- a/cx-server-companion/life-cycle-scripts/cx-server
+++ b/cx-server-companion/life-cycle-scripts/cx-server
@@ -6,7 +6,7 @@ command -v docker > /dev/null 2>&1 || { echo >&2 "Docker does not seem to be ins
 source server.cfg
 
 if [ -z "${DEVELOPER_MODE}" ]; then
-    docker pull ppiper/cx-server-companion;
+    docker pull ppiper/cx-server-companion
 fi
 
 # Run Docker without '-it' flag on Jenkins to prevent our integration test from getting stuck


### PR DESCRIPTION
The s4sdk/* images will be deprecated soon.
The cx-server-companion will be updated silently to use the ppiper image.
However it is likely that users will still have the s4sdk/jenkins-master configured in their server.cfg.

This PR offers a migration to ppiper/jenkins-master in case s4sdk/jenkins-master is recognized.