### PR TITLE
Use curl for downloading slave.jar in lauch-jenkins-agent.sh

### DIFF
--- a/jenkins-master/Dockerfile
+++ b/jenkins-master/Dockerfile
@@ -14,7 +14,6 @@ RUN apt-get update && \
         apt-transport-https \
         ca-certificates \
         curl \
-        wget \
         gnupg2 \
         software-properties-common && \
     curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - && \

--- a/jenkins-master/Dockerfile
+++ b/jenkins-master/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update && \
         apt-transport-https \
         ca-certificates \
         curl \
+        wget \
         gnupg2 \
         software-properties-common && \
     curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - && \

--- a/jenkins-master/launch-jenkins-agent.sh
+++ b/jenkins-master/launch-jenkins-agent.sh
@@ -26,7 +26,7 @@ else
 fi
 
 echo "Download slave.jar"
-wget http://localhost:8080/jnlpJars/slave.jar
+curl http://localhost:8080/jnlpJars/slave.jar -o slave.jar
 
 echo "Create directory on agent: $REMOTE_DIR"
 $SSH_COMMAND $SSH_USER@$SSH_HOST "mkdir -p $REMOTE_DIR" </dev/null


### PR DESCRIPTION
We use wget in the `launch-jenkins-agent.sh` script therefore we should install wget or use curl.
