### PR TITLE
Revert "Update Jenkinsfile runner to 1.0-beta-10 (#23)"

### DIFF
--- a/infrastructure-tests/runTests.sh
+++ b/infrastructure-tests/runTests.sh
@@ -32,7 +32,7 @@ chmod +x cx-server
 # See `Jenkinsfile` in this directory for details on what is happening.
 docker run -v //var/run/docker.sock:/var/run/docker.sock -v $(pwd):/workspace \
  -e CASC_JENKINS_CONFIG=/workspace/jenkins.yml -e HOST=$(hostname) \
- ppiper/jenkinsfile-runner
+ ppiper/jenkinsfile-runner:v2
 
 # cleanup
 if [ ! "$TRAVIS" = true ] ; then

--- a/jenkinsfile-runner-github-action/Dockerfile
+++ b/jenkinsfile-runner-github-action/Dockerfile
@@ -2,7 +2,7 @@
 # hadolint ignore=DL3006
 FROM ppiper/jenkins-master
 
-ENV JENKINSFILE_RUNNER_VERSION 1.0-beta-10
+ENV JENKINSFILE_RUNNER_VERSION 1.0-beta-9
 ENV CASC_JENKINS_CONFIG=/github/workspace/jenkins.yml
 
 VOLUME /tmp
@@ -19,9 +19,9 @@ LABEL "maintainer"="SAP SE"
 # User needs to be root for access to mounted Docker socket
 # hadolint ignore=DL3002
 USER root
-RUN curl -O https://repo.jenkins-ci.org/releases/io/jenkins/jenkinsfile-runner/jenkinsfile-runner/$JENKINSFILE_RUNNER_VERSION/jenkinsfile-runner-$JENKINSFILE_RUNNER_VERSION.zip && \
-    unzip jenkinsfile-runner-$JENKINSFILE_RUNNER_VERSION.zip -d jenkinsfile-runner && \
-    rm jenkinsfile-runner-$JENKINSFILE_RUNNER_VERSION.zip && \
+RUN curl -O https://repo.jenkins-ci.org/releases/io/jenkins/jenkinsfile-runner/jenkinsfile-runner/$JENKINSFILE_RUNNER_VERSION/jenkinsfile-runner-$JENKINSFILE_RUNNER_VERSION-app.zip && \
+    unzip jenkinsfile-runner-$JENKINSFILE_RUNNER_VERSION-app.zip -d jenkinsfile-runner && \
+    rm jenkinsfile-runner-$JENKINSFILE_RUNNER_VERSION-app.zip && \
     chmod +x /jenkinsfile-runner/bin/jenkinsfile-runner
 
 RUN mkdir /jenkins-war && unzip /usr/share/jenkins/jenkins.war -d /jenkins-war && \

--- a/jenkinsfile-runner/Dockerfile
+++ b/jenkinsfile-runner/Dockerfile
@@ -2,14 +2,14 @@
 # hadolint ignore=DL3006
 FROM ppiper/jenkins-master
 
-ENV JENKINSFILE_RUNNER_VERSION 1.0-beta-10
+ENV JENKINSFILE_RUNNER_VERSION 1.0-beta-9
 
 # User needs to be root for access to mounted Docker socket
 # hadolint ignore=DL3002
 USER root
-RUN curl -O https://repo.jenkins-ci.org/releases/io/jenkins/jenkinsfile-runner/jenkinsfile-runner/$JENKINSFILE_RUNNER_VERSION/jenkinsfile-runner-$JENKINSFILE_RUNNER_VERSION.zip && \
-    unzip jenkinsfile-runner-$JENKINSFILE_RUNNER_VERSION.zip -d jenkinsfile-runner && \
-    rm jenkinsfile-runner-$JENKINSFILE_RUNNER_VERSION.zip && \
+RUN curl -O https://repo.jenkins-ci.org/releases/io/jenkins/jenkinsfile-runner/jenkinsfile-runner/$JENKINSFILE_RUNNER_VERSION/jenkinsfile-runner-$JENKINSFILE_RUNNER_VERSION-app.zip && \
+    unzip jenkinsfile-runner-$JENKINSFILE_RUNNER_VERSION-app.zip -d jenkinsfile-runner && \
+    rm jenkinsfile-runner-$JENKINSFILE_RUNNER_VERSION-app.zip && \
     chmod +x /jenkinsfile-runner/bin/jenkinsfile-runner
 
 RUN mkdir /jenkins-war && unzip /usr/share/jenkins/jenkins.war -d /jenkins-war && \


### PR DESCRIPTION
This reverts commit 0fc87802da90c1e11197a72459d2cd5f9b715f67.

The update seems to cause issues in our use-case, so revert for now and
investigate the root cause later.