### PR TITLE
Remove warning about JRF being built from source

### DIFF
--- a/jenkinsfile-runner/README.md
+++ b/jenkinsfile-runner/README.md
@@ -20,9 +20,6 @@ To build this image locally, open a terminal in the directory of the Dockerfile 
 docker build -t ppiper/jenkinsfile-runner .
 ```
 
-**Warning:** Building this image will take quite long, as the Jenkinsfile Runner is built from source and has many dependencies.
-Expect high network traffic.
-
 ## Usage
 
 Place a `Jenkinsfile` in the current directory, for example


### PR DESCRIPTION
This was the case earlier, but is not true anymore.