### PR TITLE
Fix cx-server to be used in non interactive shell mode

### DIFF
--- a/cx-server-companion/life-cycle-scripts/cx-server
+++ b/cx-server-companion/life-cycle-scripts/cx-server
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-set -x
-
 # Ensure that Docker is installed
 command -v docker > /dev/null 2>&1 || { echo >&2 "Docker does not seem to be installed. Please install Docker and ensure that the 'docker' command is included in \$PATH."; exit 1; }
 

--- a/cx-server-companion/life-cycle-scripts/cx-server
+++ b/cx-server-companion/life-cycle-scripts/cx-server
@@ -9,21 +9,21 @@ if [ -z "${DEVELOPER_MODE}" ]; then
     docker pull ppiper/cx-server-companion;
 fi
 
-# Run Docker without '-it' flag on Jenkins to prevent our integration test from getting stuck
-if docker run --rm -it hello-world > /dev/null 2>&1 ; then
-    DOCKER_IT_FLAG='-it'
-else
-    echo No interactive terminal, run Docker without '-it' flag
-fi
-
 docker_arguments=(--rm
-    "${DOCKER_IT_FLAG}"
     --mount "source=${PWD},target=/cx-server/mount,type=bind"
     --workdir /cx-server/mount
     --volume /var/run/docker.sock:/var/run/docker.sock
     --env DEVELOPER_MODE
     --env "host_os=unix"
     --env "cx_server_path=${PWD}")
+
+# Run Docker without '-it' flag on Jenkins to prevent our integration test from getting stuck
+if docker run --rm -it hello-world > /dev/null 2>&1 ; then
+    docker_arguments+=('-it')
+else
+    echo No interactive terminal, run Docker without '-it' flag
+fi
+
 
 # Environment file is required for integration tests
 readonly env_file='custom-environment.list'

--- a/cx-server-companion/life-cycle-scripts/cx-server
+++ b/cx-server-companion/life-cycle-scripts/cx-server
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -x
+
 # Ensure that Docker is installed
 command -v docker > /dev/null 2>&1 || { echo >&2 "Docker does not seem to be installed. Please install Docker and ensure that the 'docker' command is included in \$PATH."; exit 1; }
 
@@ -30,9 +32,6 @@ readonly env_file='custom-environment.list'
 if [ -f ${env_file} ]; then
     docker_arguments+=(--env-file "${env_file}")
 fi
-
-# Print the docker command to verify if it looks good
-set -x
 
 # These braces ensure that the block in them cannot be overridden by updating this file on the fly.
 # The exit inside protects against unintended effect when the new script file is bigger than its old version.

--- a/cx-server-companion/life-cycle-scripts/cx-server
+++ b/cx-server-companion/life-cycle-scripts/cx-server
@@ -31,6 +31,9 @@ if [ -f ${env_file} ]; then
     docker_arguments+=(--env-file "${env_file}")
 fi
 
+# Print the docker command to verify if it looks good
+set -x
+
 # These braces ensure that the block in them cannot be overridden by updating this file on the fly.
 # The exit inside protects against unintended effect when the new script file is bigger than its old version.
 # See: https://stackoverflow.com/questions/3398258/edit-shell-script-while-its-running


### PR DESCRIPTION
Before the variable DOCKER_IT_FLAG was empty which created an invalided docker command in docker run "${docker_arguments[@]}"