### PR TITLE
Install workflow-cps-global-lib-http plugin

### DIFF
--- a/jenkins-master/plugins.txt
+++ b/jenkins-master/plugins.txt
@@ -45,4 +45,5 @@ warnings-ng
 workflow-aggregator
 workflow-basic-steps
 workflow-cps
+workflow-cps-global-lib-http
 workflow-multibranch


### PR DESCRIPTION
The reasoning for this plugin is described in the readme: https://github.com/jenkinsci/workflow-cps-global-lib-http-plugin

In short: It allows us to package our Jenkins libraries in a zip file without non-required stuff like docs, images, tests etc and thus potentially reduce the size of downloads. In some circumstances we have seen that getting libraries via git can be quite slow, so this plugin might provide a mitigation in those cases. I briefly tested it, and it worked like I expected it for now.