### PR TITLE
Fix misleading error message

### DIFF
--- a/cx-server-companion/files/cx-server-companion.sh
+++ b/cx-server-companion/files/cx-server-companion.sh
@@ -720,7 +720,7 @@ function restore_volume()
     local backup_filepath="${backup_folder}/${backup_filename}"
 
     if [[ ! -f "${backup_filepath}" ]]; then
-        log_error "Backup file '${backup_filename}' can not be read or does not exist in backup folder."
+        log_error "Backup file '${backup_filepath}' can not be read or does not exist."
         exit 1
     fi
 


### PR DESCRIPTION
The if condition checks for `${backup_filePath}` which is concatinated via `${backup_folder}` and
`${backup_filename}`. The error message afterwards in case the file is not found only prompts
the `${backup_filepath}.

That is misleading since another path is checked than is prompted by the error message.