### PR TITLE
Check read access for backup file

### DIFF
--- a/cx-server-companion/files/cx-server-companion.sh
+++ b/cx-server-companion/files/cx-server-companion.sh
@@ -719,7 +719,7 @@ function restore_volume()
     local backup_filename="${1}"
     local backup_filepath="${backup_folder}/${backup_filename}"
 
-    if [[ ! -f "${backup_filepath}" ]]; then
+    if [[ ! -r "${backup_filepath}" ]]; then
         log_error "Backup file '${backup_filename}' can not be read or does not exist in backup folder."
         exit 1
     fi


### PR DESCRIPTION
Up to now we check that the file exists. In the log message we say:
'file does not exist or cannot be read'.

With the current approach we survive the check in case the file is
present, but cannot be read.