### PR TITLE
Support XSRF enabled Jenkins instances

### DIFF
--- a/cx-server-companion/files/cx-server-companion.sh
+++ b/cx-server-companion/files/cx-server-companion.sh
@@ -137,7 +137,8 @@ function retry()
 
 function trace_execution()
 {
-    echo -e "\033[1m>>\033[0m" $*
+    echo -e -n "\033[1m>>\033[0m " >&2
+    echo $* >&2
 }
 
 function run()

--- a/cx-server-companion/files/cx-server-companion.sh
+++ b/cx-server-companion/files/cx-server-companion.sh
@@ -273,7 +273,7 @@ function stop_jenkins_container()
     echo ""
     echo "Initiating safe shutdown..."
 
-    crumb_header_snippet=`get_crumb_header_snippet "${jenkins_container_name}" "http://localhost:${container_port_http}" "${user_and_pass[@]}"`
+    crumb_header_snippet=`get_crumb_header_snippet "${jenkins_container_name}" "${container_port_http}" "${user_and_pass[@]}"`
     [ "$?" != 0 ] && die "Cannot retrieve XSRF crumb. Check log for details" 1
 
     exitCmd=(docker exec ${jenkins_container_name} curl --noproxy localhost --write-out '%{http_code}' --output /dev/null --silent "${user_and_pass[@]}" ${crumb_header_snippet} -X POST "http://localhost:${container_port_http}/safeExit")
@@ -965,10 +965,10 @@ function get_port_mapping(){
 function get_crumb_header_snippet {
 
     local JENKINS_CONTAINER_NAME=$1; shift
-    local HOST=$1; shift
+    local PORT=$1; shift
     local USER_SNIPPET=$@;
 
-    CRUMB_CMD=(docker exec ${JENKINS_CONTAINER_NAME} curl -w "\nHTTP_CODE:%{http_code}\n" ${USER_SNIPPET} ${HOST}/crumbIssuer/api/xml?xpath=concat\(//crumbRequestField,%22:%22,//crumb\))
+    CRUMB_CMD=(docker exec ${JENKINS_CONTAINER_NAME} curl -w "\nHTTP_CODE:%{http_code}\n" ${USER_SNIPPET} --noproxy localhost http://localhost:${PORT}/crumbIssuer/api/xml?xpath=concat\(//crumbRequestField,%22:%22,//crumb\))
 
     if [ ! -z "${password}" ]; then
         trace_execution "${CRUMB_CMD[@]//${password}/******}"

--- a/cx-server-companion/files/cx-server-companion.sh
+++ b/cx-server-companion/files/cx-server-companion.sh
@@ -21,6 +21,15 @@ readonly alpine_docker_image='alpine:3.9'
 readonly bold_start="\033[1m"
 readonly bold_end="\033[0m"
 
+function die()
+{
+    local msg=$1; shift
+    local rc=${1:-1}; shift
+    [ -n "${msg}" ] && log_error "${msg}"
+    [ "${rc}" == "0" ] && log_warn "function \"die\" called with exit code \"${rc}\". This indicates a normal termination."
+    exit ${rc}
+}
+
 function log_error()
 {
     echo -e "\033[1;31m[Error]\033[0m $1" >&2

--- a/cx-server-companion/files/cx-server-companion.sh
+++ b/cx-server-companion/files/cx-server-companion.sh
@@ -968,7 +968,15 @@ function get_crumb_header_snippet {
     local HOST=$1; shift
     local USER_SNIPPET=$@;
 
-    local CRUMB_RESPONSE=$(docker exec ${JENKINS_CONTAINER_NAME} curl -w "\nHTTP_CODE:%{http_code}\n" ${USER_SNIPPET} ${HOST}/crumbIssuer/api/xml?xpath=concat\(//crumbRequestField,%22:%22,//crumb\) 2>/dev/null)
+    CRUMB_CMD=(docker exec ${JENKINS_CONTAINER_NAME} curl -w "\nHTTP_CODE:%{http_code}\n" ${USER_SNIPPET} ${HOST}/crumbIssuer/api/xml?xpath=concat\(//crumbRequestField,%22:%22,//crumb\))
+
+    if [ ! -z "${password}" ]; then
+        trace_execution "${CRUMB_CMD[@]//${password}/******}"
+    else
+        trace_execution "${CRUMB_CMD[@]}"
+    fi
+
+    local CRUMB_RESPONSE=$("${CRUMB_CMD[@]}" 2>/dev/null)
 
     local HTTP_CODE=$(echo "${CRUMB_RESPONSE}" |grep HTTP_CODE |sed 's/HTTP_CODE://g')
     local CRUMB_SNIPPET=""


### PR DESCRIPTION
Stopping a Jenkins Server via `./cx-server stop` or restoring a backup via `./cx-server restore` does not work when XSRF protection is active ("Manage Jenkins" >> "Configure Global Security" >> "Prevent Cross Site Request Forgery exploits".

In this case we get a `403`.

This PR includes:

- a new `die` function: writes a log message with level `error` and exist. Message and exit code can be provided.
- function `trace_execution` has been reworked. Only the leading `>>` are beautified with colours now. The command "as it" gets not beautified, and this is also not necessary. Without that a command containing `\n` gets spread over several lines.
- In case of emitting a "safeExit` command we try to get the crumb first. In case XSRF support is active (... we do not end up in a 404 (not found)) we set the crumb header in the subsequent "safeExit" request.
- We store the cookies (--> session coolie) from the crumb request (if any) and hand it over to the second request performing the `safeExit` (only in case we received a crumb from the first call).
 