### PR TITLE
Fixed issue #41 of origin

### DIFF
--- a/cx-server-companion/files/cx-server-companion.sh
+++ b/cx-server-companion/files/cx-server-companion.sh
@@ -9,7 +9,7 @@ readonly container_port_https=8443
 readonly network_name='cx-network'
 #Two times rev in combination with cut -f1 returns the last element of the cgroup which corresponds to the container id
 #Returns f323454ad3402f2513712 applied to 10:name=systemd:/docker/f323454ad3402f2513712
-readonly cxserver_companion_container_id="$(head -n 1 /proc/self/cgroup | rev | cut -d '/' -f1 | rev)"
+readonly cxserver_companion_container_id="$(grep memory /proc/self/cgroup | rev | cut -d '/' -f1 | rev)"
 
 readonly cxserver_mount=/cx-server/mount
 readonly backup_folder="${cxserver_mount}/backup"


### PR DESCRIPTION
Fixed the issue #41 of the origin sources that backup fails randomly. 

Uses grep for "memory" instead of using the first line item of /proc/self/cgroup.

Note that this is a bloody hack as https://stackoverflow.com/questions/20995351/how-can-i-get-docker-linux-container-information-from-within-the-container-itsel and https://forums.docker.com/t/get-a-containers-full-id-from-inside-of-itself/37237 imply that this might not be a guaranteed feature of docker