### PR TITLE
Don't push daily image on the weekend

### DIFF
--- a/.github/workflows/push-master.yml
+++ b/.github/workflows/push-master.yml
@@ -3,7 +3,7 @@ on:
     branches:
       - "**"
   schedule:
-    - cron:  '0 6 * * *'
+    - cron:  '0 6 * * 1-4'
 
 name: Build images
 jobs:


### PR DESCRIPTION
Only re-build and push the Jenkins master image during the week to minimize possible issues on a weekend.