### PR TITLE
Allow path to backup file in restore command

### DIFF
--- a/cx-server-companion/files/cx-server-companion.sh
+++ b/cx-server-companion/files/cx-server-companion.sh
@@ -747,7 +747,7 @@ function restore_volume()
 
     local backup_filename
 
-    if [[ "${1}" == *"/"* ]]; then
+    if [[ "${1}" == *"./backup/"* ]]; then
         backup_filename=$(echo "${1}" | sed 's|.*/||')
     else
         backup_filename="${1}"

--- a/cx-server-companion/files/cx-server-companion.sh
+++ b/cx-server-companion/files/cx-server-companion.sh
@@ -747,7 +747,7 @@ function restore_volume()
 
     local backup_filename
 
-    if [[ "${1}" == *"./backup/"* ]]; then
+    if [[ "${1}" == "./backup/"* ]] || [[ "${1}" == "backup/"* ]]; then
         backup_filename=$(echo "${1}" | sed 's|.*/||')
     else
         backup_filename="${1}"

--- a/cx-server-companion/files/cx-server-companion.sh
+++ b/cx-server-companion/files/cx-server-companion.sh
@@ -745,7 +745,14 @@ function restore_volume()
         exit 1
     fi
 
-    local backup_filename="${1}"
+    local backup_filename
+
+    if [[ "${1}" == *"/"* ]]; then
+        backup_filename=$(echo "${1}" | sed 's|.*/||')
+    else
+        backup_filename="${1}"
+    fi
+
     local backup_filepath="${backup_folder}/${backup_filename}"
 
     if [[ ! -r "${backup_filepath}" ]]; then

--- a/cx-server-companion/files/cx-server-companion.sh
+++ b/cx-server-companion/files/cx-server-companion.sh
@@ -746,17 +746,19 @@ function restore_volume()
     fi
 
     local backup_filename
+    local backup_filepath
 
-    if [[ "${1}" == "./backup/"* ]] || [[ "${1}" == "backup/"* ]]; then
-        backup_filename=$(echo "${1}" | sed 's|.*/||')
+    if [[ "${1}" != *"/"* ]]; then
+	backup_filename="${1}"
+	backup_filepath="${backup_folder}/${backup_filename}"
+
     else
-        backup_filename="${1}"
+        backup_filename="$(basename -- ${1})"
+        backup_filepath="$(realpath ${1})"
     fi
 
-    local backup_filepath="${backup_folder}/${backup_filename}"
-
     if [[ ! -r "${backup_filepath}" ]]; then
-        log_error "Backup file '${backup_filename}' can not be read or does not exist in backup folder."
+        log_error "Backup file '${backup_filename}' can not be read or does not exist in '${backup_filepath}'."
 
         exit 1
     fi

--- a/docs/operations/cx-server-operations-guide.md
+++ b/docs/operations/cx-server-operations-guide.md
@@ -111,7 +111,7 @@ This command creates a backup file and stores it on a host machine inside a dire
 
 ##### restore
 
-In an event of a server crash, the state of the Jenkins can be restored to a previously saved state if there is a backup file available. You need to execute the `restore` command along with the absolute path to the backup file that you want to restore the state to.
+In an event of a server crash, the state of the Jenkins can be restored to a previously saved state if there is a backup file available. You need to execute the `restore` command along with the name of the backup file that you want to restore the state to.
  
 Example:
 


### PR DESCRIPTION
This change enables the user to provide the path (absolute or relative)
to the backup file, instead of just the backup filename.

Previously, ./cx-server restore only allowed the name of the backup
file as an argument. The backup file, however, does not reside in the
folder from where the cx-server script is usually executed. Instead,
the backup file resides in the folder backup/, making it difficult for
the user to determine the filename. It is easier for users to make use
of shell autocompletion, thus providing a path relative to the current
folder.

Issue #37 