### PR TITLE
Set random default password for admin user

### DIFF
--- a/.github/workflows/push-master.yml
+++ b/.github/workflows/push-master.yml
@@ -3,7 +3,7 @@ on:
     branches:
       - "**"
   schedule:
-    - cron:  '0 6 * * *'
+    - cron:  '0 6 * * 1-4'
 
 name: Build images
 jobs:

--- a/cx-server-companion/files/cx-server-companion.sh
+++ b/cx-server-companion/files/cx-server-companion.sh
@@ -7,9 +7,8 @@ readonly cxserver_companion_docker_image='ppiper/cx-server-companion'
 readonly container_port_http=8080
 readonly container_port_https=8443
 readonly network_name='cx-network'
-#Two times rev in combination with cut -f1 returns the last element of the cgroup which corresponds to the container id
-#Returns f323454ad3402f2513712 applied to 10:name=systemd:/docker/f323454ad3402f2513712
-readonly cxserver_companion_container_id="$(head -n 1 /proc/self/cgroup | rev | cut -d '/' -f1 | rev)"
+# cf https://gist.github.com/nmarley/0ee3e2cf14dabfb868eb818b8b30e7e0#gistcomment-2318045
+readonly cxserver_companion_container_id="$(awk -F/ '{ print $NF }' /proc/1/cpuset)"
 
 readonly cxserver_mount=/cx-server/mount
 readonly backup_folder="${cxserver_mount}/backup"

--- a/cx-server-companion/files/cx-server-companion.sh
+++ b/cx-server-companion/files/cx-server-companion.sh
@@ -519,11 +519,13 @@ function start_jenkins()
         log_info "Cx Server is already running."
     fi
 
-    log_warn 'Please ensure your Jenkins instance is appropriatly secured, see: https://jenkins.io/doc/book/system-administration/security/
+    if [ -z ${DEVELOPER_MODE} ]; then
+        log_warn 'Please ensure your Jenkins instance is appropriatly secured, see: https://jenkins.io/doc/book/system-administration/security/
 A random password was created for admin, if your Jenkins instance was not secured already.
 Run docker logs -f cx-jenkins-master 2>&1 | grep "Default credentials for Jenkins"
 to find the default credentials. This might take a few minutes to complete.
 We recommend to change the default password immediately.'
+    fi
 
 }
 
@@ -647,6 +649,8 @@ function start_jenkins_container()
         do
             environment_variable_parameters+=(-e $var)
         done
+
+        environment_variable_parameters+=(-e DEVELOPER_MODE)
 
         if [ ! -z "${cx_server_path}" ]; then
             if [ "${host_os}" = windows ] ; then

--- a/cx-server-companion/files/cx-server-companion.sh
+++ b/cx-server-companion/files/cx-server-companion.sh
@@ -747,6 +747,7 @@ function display_help()
     command_help_text 'restore'       "Restores the content of the configured 'jenkins_home' by the contents of the provided backup file. Usage: 'cx-server restore <name of the backup file>'."
     command_help_text 'update script' "Explicitly pull the Docker image containing this script to update to its latest version. Running this is not required, since the image is updated automatically."
     command_help_text 'update image'  "Updates the configured 'docker_image' to the newest available version of Cx Server image on Docker Hub."
+    command_help_text 'initial-credentials' "Shows initial admin credentials."
     command_help_text 'help'          "Shows this help text."
 }
 

--- a/cx-server-companion/files/cx-server-companion.sh
+++ b/cx-server-companion/files/cx-server-companion.sh
@@ -522,8 +522,9 @@ function start_jenkins()
     if [ -z ${DEVELOPER_MODE} ]; then
         log_warn 'Please ensure your Jenkins instance is appropriatly secured, see: https://jenkins.io/doc/book/system-administration/security/
 A random password was created for admin, if your Jenkins instance was not secured already.
-Run docker logs -f cx-jenkins-master 2>&1 | grep "Default credentials for Jenkins"
-to find the default credentials. This might take a few minutes to complete.
+Run "./cx-server initial-credentials" to find the default credentials.
+This might take a few minutes to complete.
+
 We recommend to change the default password immediately.'
     fi
 
@@ -1082,6 +1083,8 @@ elif [ "$1" == "help" ]; then
     warn_low_memory
 elif [ "$1" == "status" ]; then
     node /cx-server/status.js "{\"cache_enabled\": \"${cache_enabled}\"}"
+elif [ "$1" == "initial-credentials" ]; then
+    docker logs cx-jenkins-master 2>&1 | grep "Default credentials for Jenkins"
 else
     display_help "$1"
     warn_low_memory

--- a/cx-server-companion/files/cx-server-companion.sh
+++ b/cx-server-companion/files/cx-server-companion.sh
@@ -518,6 +518,15 @@ function start_jenkins()
     else
         log_info "Cx Server is already running."
     fi
+
+    if [ -z ${DEVELOPER_MODE} ]; then
+        log_warn 'Please ensure your Jenkins instance is appropriatly secured, see: https://jenkins.io/doc/book/system-administration/security/
+A random password was created for admin, if your Jenkins instance was not secured already.
+Run docker logs -f cx-jenkins-master 2>&1 | grep "Default credentials for Jenkins"
+to find the default credentials. This might take a few minutes to complete.
+We recommend to change the default password immediately.'
+    fi
+
 }
 
 function start_jenkins_container()
@@ -640,6 +649,8 @@ function start_jenkins_container()
         do
             environment_variable_parameters+=(-e $var)
         done
+
+        environment_variable_parameters+=(-e DEVELOPER_MODE)
 
         if [ ! -z "${cx_server_path}" ]; then
             if [ "${host_os}" = windows ] ; then

--- a/cx-server-companion/files/cx-server-companion.sh
+++ b/cx-server-companion/files/cx-server-companion.sh
@@ -519,13 +519,11 @@ function start_jenkins()
         log_info "Cx Server is already running."
     fi
 
-    if [ -z ${DEVELOPER_MODE} ]; then
-        log_warn 'Please ensure your Jenkins instance is appropriatly secured, see: https://jenkins.io/doc/book/system-administration/security/
+    log_warn 'Please ensure your Jenkins instance is appropriatly secured, see: https://jenkins.io/doc/book/system-administration/security/
 A random password was created for admin, if your Jenkins instance was not secured already.
 Run docker logs -f cx-jenkins-master 2>&1 | grep "Default credentials for Jenkins"
 to find the default credentials. This might take a few minutes to complete.
 We recommend to change the default password immediately.'
-    fi
 
 }
 
@@ -649,8 +647,6 @@ function start_jenkins_container()
         do
             environment_variable_parameters+=(-e $var)
         done
-
-        environment_variable_parameters+=(-e DEVELOPER_MODE)
 
         if [ ! -z "${cx_server_path}" ]; then
             if [ "${host_os}" = windows ] ; then

--- a/cx-server-companion/files/init-cx-server
+++ b/cx-server-companion/files/init-cx-server
@@ -9,3 +9,5 @@ else
     echo "The cx-server and the server.cfg files have been successfully generated."
     echo "Execute ./cx-server help command to know more about the cx-server script"
 fi
+
+echo "Make sure to secure your Jenkins instance, see CX-SERVER-SECURITY.md for details."

--- a/cx-server-companion/life-cycle-scripts/CX-SERVER-SECURITY.md
+++ b/cx-server-companion/life-cycle-scripts/CX-SERVER-SECURITY.md
@@ -1,0 +1,20 @@
+# Notes on running CX Server in Production
+
+Please be aware that running a Jenkins in production securly is not a trivial task.
+
+Some recommendations:
+
+The `latest` tag of CX Server Docker images are rebuilt on a regular basis.
+To benefit from updated Jenkins core and plugin versions, you should stop, remove and restart your CX Server instance on a regular basis.
+Part of this procedure should be to take backups (see `backup` and `restore` commands of `cx-server`).
+The commands perform an update of CX Server are:
+
+```
+./cx-server stop
+./cx-server remove
+./cx-server start
+```
+
+If you use released versions of the CX Server, look for new releases on https://github.com/SAP/devops-docker-cx-server/releases
+
+In addition, we recomment to [read about "Securing Jenkins"](https://jenkins.io/doc/book/system-administration/security/) in the Jenkins manual.

--- a/cx-server-companion/life-cycle-scripts/CX-SERVER-SECURITY.md
+++ b/cx-server-companion/life-cycle-scripts/CX-SERVER-SECURITY.md
@@ -1,6 +1,6 @@
 # Notes on running CX Server in Production
 
-Please be aware that running a Jenkins in production securly is not a trivial task.
+Please be aware that running a Jenkins in production securely is not a trivial task.
 
 Some recommendations:
 

--- a/cx-server-companion/life-cycle-scripts/CX-SERVER-SECURITY.md
+++ b/cx-server-companion/life-cycle-scripts/CX-SERVER-SECURITY.md
@@ -4,6 +4,9 @@ Please be aware that running a Jenkins in production securly is not a trivial ta
 
 Some recommendations:
 
+Jenkins has a default password for the `admin` account set.
+You can get it by running `./cx-server initial-credentials` once your Jenkins is up and running.
+
 The `latest` tag of the CX Server Docker images are rebuilt on a regular basis.
 To benefit from updated Jenkins core and plugin versions, you should stop, remove, and restart your CX Server instance on a regular basis.
 Part of this procedure should be to take backups (see `backup` and `restore` commands of `cx-server`).

--- a/cx-server-companion/life-cycle-scripts/cx-server-completion.bash
+++ b/cx-server-companion/life-cycle-scripts/cx-server-completion.bash
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-complete -W "start status stop remove backup restore update image script help" cx-server
+complete -W "start status stop remove backup restore update image script help initial-credentials" cx-server

--- a/docs/development/running-cx-server-in-development.md
+++ b/docs/development/running-cx-server-in-development.md
@@ -9,7 +9,7 @@ When you make changes to `cx-server-companion/cx-server-companion.sh`, you need 
 From this directory (`jenkins-master/cx-server`), the command to do so is:
 
 ```bash
-docker build [--build-arg cx_server_base_uri=https://github.some.domain/raw/path/to/cx-server] -t ppiper/cx-server-companion ../../ppiper-cx-server-companion
+docker build [--build-arg cx_server_base_uri=https://github.some.domain/raw/path/to/cx-server] -t ppiper/cx-server-companion ../../cx-server-companion
 ```
 
 The build argument `cx_server_base_uri` is optional and only required if you don't want to use the `cx-server` version from GitHub.com.

--- a/infrastructure-tests/runTests.sh
+++ b/infrastructure-tests/runTests.sh
@@ -36,21 +36,15 @@ docker run -v //var/run/docker.sock:/var/run/docker.sock -v $(pwd):/workspace \
 
 # Test Jenkins default admin credentials
 INITIAL_CREDENTIALS=$(docker logs cx-jenkins-master 2>&1 | grep "Default credentials for Jenkins")
-echo $INITIAL_CREDENTIALS
 ADMIN_PASSWORD=$(echo ${INITIAL_CREDENTIALS} | cut -c 63-)
-echo $ADMIN_PASSWORD
-
-# Expect code 403
+# Expect code 403 Forbidden because we are not authorized
 ACTUAL_STATUS_CODE_WITHOUT_AUTH=$(curl -s -o /dev/null -w "%{http_code}" -X POST http://localhost/createItem)
-echo $ACTUAL_STATUS_CODE_WITHOUT_AUTH
 if [ "$ACTUAL_STATUS_CODE_WITHOUT_AUTH" != "403" ]; then
     echo Expected status 403, but got $ACTUAL_STATUS_CODE_WITHOUT_AUTH
     exit 122
 fi
-
-# Expect code 400
+# Expect code 400 Bad Request because we are authorized but don't pass the required parameters
 ACTUAL_STATUS_CODE_WITH_AUTH=$(curl --user admin:$ADMIN_PASSWORD -X POST -s -o /dev/null -w "%{http_code}" http://localhost/createItem)
-echo $ACTUAL_STATUS_CODE_WITH_AUTH
 if [ "$ACTUAL_STATUS_CODE_WITH_AUTH" != "400" ]; then
     echo Expected status 400, but got $ACTUAL_STATUS_CODE_WITH_AUTH
     exit 123

--- a/infrastructure-tests/runTests.sh
+++ b/infrastructure-tests/runTests.sh
@@ -34,6 +34,9 @@ docker run -v //var/run/docker.sock:/var/run/docker.sock -v $(pwd):/workspace \
  -e CASC_JENKINS_CONFIG=/workspace/jenkins.yml -e HOST=$(hostname) \
  ppiper/jenkinsfile-runner:v2
 
+#todo assert here
+./cx-server initial-credentials
+
 # cleanup
 if [ ! "$TRAVIS" = true ] ; then
     rm -f cx-server server.cfg custom-environment.list

--- a/infrastructure-tests/runTests.sh
+++ b/infrastructure-tests/runTests.sh
@@ -34,19 +34,27 @@ docker run -v //var/run/docker.sock:/var/run/docker.sock -v $(pwd):/workspace \
  -e CASC_JENKINS_CONFIG=/workspace/jenkins.yml -e HOST=$(hostname) \
  ppiper/jenkinsfile-runner:v2
 
-#todo assert here
-INITIAL_CREDENTIALS=$(./cx-server initial-credentials)
+# Test Jenkins default admin credentials
+INITIAL_CREDENTIALS=$(docker logs cx-jenkins-master 2>&1 | grep "Default credentials for Jenkins")
 echo $INITIAL_CREDENTIALS
 ADMIN_PASSWORD=$(echo ${INITIAL_CREDENTIALS} | cut -c 63-)
 echo $ADMIN_PASSWORD
 
 # Expect code 403
-CODE_WITHOUT_AUTH=$(curl -s -o /dev/null -w "%{http_code}" -X POST http://localhost/createItem)
-echo $CODE_WITHOUT_AUTH
+ACTUAL_STATUS_CODE_WITHOUT_AUTH=$(curl -s -o /dev/null -w "%{http_code}" -X POST http://localhost/createItem)
+echo $ACTUAL_STATUS_CODE_WITHOUT_AUTH
+if [ "$ACTUAL_STATUS_CODE_WITHOUT_AUTH" != "403" ]; then
+    echo Expected status 403, but got $ACTUAL_STATUS_CODE_WITHOUT_AUTH
+    exit 122
+fi
 
 # Expect code 400
-CODE_WITH_AUTH=$(curl --user admin:$ADMIN_PASSWORD -X POST -s -o /dev/null -w "%{http_code}" http://localhost/createItem)
-echo $CODE_WITH_AUTH
+ACTUAL_STATUS_CODE_WITH_AUTH=$(curl --user admin:$ADMIN_PASSWORD -X POST -s -o /dev/null -w "%{http_code}" http://localhost/createItem)
+echo $ACTUAL_STATUS_CODE_WITH_AUTH
+if [ "$ACTUAL_STATUS_CODE_WITH_AUTH" != "400" ]; then
+    echo Expected status 400, but got $ACTUAL_STATUS_CODE_WITH_AUTH
+    exit 123
+fi
 
 # cleanup
 if [ ! "$TRAVIS" = true ] ; then

--- a/infrastructure-tests/runTests.sh
+++ b/infrastructure-tests/runTests.sh
@@ -35,7 +35,15 @@ docker run -v //var/run/docker.sock:/var/run/docker.sock -v $(pwd):/workspace \
  ppiper/jenkinsfile-runner:v2
 
 #todo assert here
-./cx-server initial-credentials
+INITIAL_CREDENTIALS=$(./cx-server initial-credentials)
+ADMIN_PASSWORD=$(echo ${INITIAL_CREDENTIALS} | cut -c 63-)
+
+
+#403
+curl -s -o /dev/null -w "%{http_code}" -X POST http://localhost/createItem
+
+#400
+curl --user admin:$ADMIN_PASSWORD -X POST -s -o /dev/null -w "%{http_code}" http://localhost/createItem
 
 # cleanup
 if [ ! "$TRAVIS" = true ] ; then

--- a/infrastructure-tests/runTests.sh
+++ b/infrastructure-tests/runTests.sh
@@ -36,14 +36,17 @@ docker run -v //var/run/docker.sock:/var/run/docker.sock -v $(pwd):/workspace \
 
 #todo assert here
 INITIAL_CREDENTIALS=$(./cx-server initial-credentials)
+echo $INITIAL_CREDENTIALS
 ADMIN_PASSWORD=$(echo ${INITIAL_CREDENTIALS} | cut -c 63-)
+echo $ADMIN_PASSWORD
 
+# Expect code 403
+CODE_WITHOUT_AUTH=$(curl -s -o /dev/null -w "%{http_code}" -X POST http://localhost/createItem)
+echo $CODE_WITHOUT_AUTH
 
-#403
-curl -s -o /dev/null -w "%{http_code}" -X POST http://localhost/createItem
-
-#400
-curl --user admin:$ADMIN_PASSWORD -X POST -s -o /dev/null -w "%{http_code}" http://localhost/createItem
+# Expect code 400
+CODE_WITH_AUTH=$(curl --user admin:$ADMIN_PASSWORD -X POST -s -o /dev/null -w "%{http_code}" http://localhost/createItem)
+echo $CODE_WITH_AUTH
 
 # cleanup
 if [ ! "$TRAVIS" = true ] ; then

--- a/jenkins-master/init_jenkins.groovy
+++ b/jenkins-master/init_jenkins.groovy
@@ -25,11 +25,8 @@ try {
     initExecutors()
     initLibraries()
 
-    // debug
-    System.getenv().each {
-        println(it)
-    }
-    println("instance.isUseSecurity() ${instance.isUseSecurity()}")
+    println("Value of `instance.isUseSecurity()`: ${instance.isUseSecurity()}")
+    println("Value of `System.getenv()['DEVELOPER_MODE']`: ${System.getenv()['DEVELOPER_MODE']}")
 
     if (System.getenv()['DEVELOPER_MODE']) {
         println("Running in developer mode, no security is enforced.")
@@ -44,15 +41,10 @@ catch(Throwable t) {
 def initAdminUser() {
     // cf https://github.com/jenkinsci/docker/issues/310
     instance.setSecurityRealm(new HudsonPrivateSecurityRealm(false))
-
-    //debug
-    instance.getSecurityRealm().getAllUsers().each {
-        println(it)
-    }
-
     String username = 'admin'
     String password = java.util.UUID.randomUUID()
     def user = instance.getSecurityRealm().createAccount(username, password)
+    // This println is API for the cx-server script and for the infra tests. Don't change.
     println(">>> Default credentials for Jenkins: Username ${username}, Password ${password}")
     user.save()
     def strategy = new FullControlOnceLoggedInAuthorizationStrategy()

--- a/jenkins-master/init_jenkins.groovy
+++ b/jenkins-master/init_jenkins.groovy
@@ -24,9 +24,7 @@ try {
     initProxy()
     initExecutors()
     initLibraries()
-    if (System.getenv()['DEVELOPER_MODE']) {
-        println("Running in developer mode, no security is enforced.")
-    } else if (!instance.isUseSecurity()) {
+    if (!instance.isUseSecurity()) {
         initAdminUser()
     }
 }

--- a/jenkins-master/init_jenkins.groovy
+++ b/jenkins-master/init_jenkins.groovy
@@ -24,7 +24,9 @@ try {
     initProxy()
     initExecutors()
     initLibraries()
-    if (!instance.isUseSecurity()) {
+    if (System.getenv()['DEVELOPER_MODE']) {
+        println("Running in developer mode, no security is enforced.")
+    } else if (!instance.isUseSecurity()) {
         initAdminUser()
     }
 }

--- a/jenkins-master/init_jenkins.groovy
+++ b/jenkins-master/init_jenkins.groovy
@@ -41,7 +41,6 @@ catch(Throwable t) {
     throw new Error("Failed to properly initialize Piper Jenkins. Please check the logs for more details.", t);
 }
 
-
 def initAdminUser() {
     // cf https://github.com/jenkinsci/docker/issues/310
     instance.setSecurityRealm(new HudsonPrivateSecurityRealm(false))

--- a/jenkins-master/init_jenkins.groovy
+++ b/jenkins-master/init_jenkins.groovy
@@ -24,6 +24,13 @@ try {
     initProxy()
     initExecutors()
     initLibraries()
+
+    // debug
+    System.getenv().each {
+        println(it)
+    }
+    println("instance.isUseSecurity() ${instance.isUseSecurity()}")
+
     if (System.getenv()['DEVELOPER_MODE']) {
         println("Running in developer mode, no security is enforced.")
     } else if (!instance.isUseSecurity()) {
@@ -38,6 +45,12 @@ catch(Throwable t) {
 def initAdminUser() {
     // cf https://github.com/jenkinsci/docker/issues/310
     instance.setSecurityRealm(new HudsonPrivateSecurityRealm(false))
+
+    //debug
+    instance.getSecurityRealm().getAllUsers().each {
+        println(it)
+    }
+
     String username = 'admin'
     String password = java.util.UUID.randomUUID()
     def user = instance.getSecurityRealm().createAccount(username, password)

--- a/jenkins-master/init_jenkins.groovy
+++ b/jenkins-master/init_jenkins.groovy
@@ -7,6 +7,8 @@ import jenkins.plugins.git.GitSCMSource
 import org.jenkinsci.plugins.workflow.libs.*
 import java.net.URLDecoder
 import java.util.logging.Logger
+import hudson.security.*
+import jenkins.install.InstallState
 
 @Field
 Jenkins instance = Jenkins.instance
@@ -22,12 +24,29 @@ try {
     initProxy()
     initExecutors()
     initLibraries()
+    if (System.getenv()['DEVELOPER_MODE']) {
+        println("Running in developer mode, no security is enforced.")
+    } else if (!instance.isUseSecurity()) {
+        initAdminUser()
+    }
 }
 catch(Throwable t) {
     throw new Error("Failed to properly initialize Piper Jenkins. Please check the logs for more details.", t);
 }
 
 
+def initAdminUser() {
+    // cf https://github.com/jenkinsci/docker/issues/310
+    instance.setSecurityRealm(new HudsonPrivateSecurityRealm(false))
+    String username = 'admin'
+    String password = java.util.UUID.randomUUID()
+    def user = instance.getSecurityRealm().createAccount(username, password)
+    println(">>> Default credentials for Jenkins: Username ${username}, Password ${password}")
+    user.save()
+    def strategy = new FullControlOnceLoggedInAuthorizationStrategy()
+    instance.setAuthorizationStrategy(strategy)
+    instance.save()
+}
 
 def initExecutors(){
     int numberOfExecutors = 6
@@ -43,7 +62,7 @@ def initLibraries(){
     String piperLibraryOsUrl = env.PIPER_LIBRARY_OS_URL ?: "https://github.com/SAP/jenkins-library.git"
     String piperLibraryOsBranch = env.PIPER_LIBRARY_OS_BRANCH ?: "master"
     createLibIfMissing("piper-lib-os", piperLibraryOsUrl, piperLibraryOsBranch)
-    
+
     String s4sdkLibraryUrl = env.S4SDK_LIBRARY_URL ?: "https://github.com/SAP/cloud-s4-sdk-pipeline-lib.git"
     String s4sdkLibraryBranch = env.S4SDK_LIBRARY_BRANCH ?: "master"
     createLibIfMissing("s4sdk-pipeline-library", s4sdkLibraryUrl, s4sdkLibraryBranch)


### PR DESCRIPTION
Secure Jenkins instance by default by setting a random password for the admin user. This is done only if Jenkins is not already secured (in jenkins home volume). The password is written to stdout so it is reachable via docker logs.
