### PR TITLE
Change method to get container id inside companion

### DIFF
--- a/cx-server-companion/files/cx-server-companion.sh
+++ b/cx-server-companion/files/cx-server-companion.sh
@@ -7,9 +7,8 @@ readonly cxserver_companion_docker_image='ppiper/cx-server-companion'
 readonly container_port_http=8080
 readonly container_port_https=8443
 readonly network_name='cx-network'
-#Two times rev in combination with cut -f1 returns the last element of the cgroup which corresponds to the container id
-#Returns f323454ad3402f2513712 applied to 10:name=systemd:/docker/f323454ad3402f2513712
-readonly cxserver_companion_container_id="$(head -n 1 /proc/self/cgroup | rev | cut -d '/' -f1 | rev)"
+# Taken from https://gist.github.com/nmarley/0ee3e2cf14dabfb868eb818b8b30e7e0#gistcomment-2318045
+readonly cxserver_companion_container_id="$(awk -F/ '{ print $NF }' /proc/1/cpuset)"
 
 readonly cxserver_mount=/cx-server/mount
 readonly backup_folder="${cxserver_mount}/backup"


### PR DESCRIPTION
The old method seems to be unstable, lots of builds failed on travis due to this.