### PR TITLE
Regular rebuild and release of images

### DIFF
--- a/.github/workflows/push-master.yml
+++ b/.github/workflows/push-master.yml
@@ -1,4 +1,4 @@
-name: Build images and push master commits or on schedule
+name: Build images and push (on master branch or on schedule)
 
 on:
   push:
@@ -13,4 +13,4 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Run CI
-      run: ./ci.sh latest  ${{ secrets.DOCKERHUB_PASSWORD }} ${{ secrets.DOCKERHUB_USER }}
+      run: ./ci.sh latest ${{ secrets.DOCKERHUB_PASSWORD }} ${{ secrets.DOCKERHUB_USER }}

--- a/.github/workflows/push-master.yml
+++ b/.github/workflows/push-master.yml
@@ -12,5 +12,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - name: Build and smoke-test a release candidate of the Docker image
+    - name: Run CI
       run: ./ci.sh latest  ${{ secrets.DOCKERHUB_PASSWORD }} ${{ secrets.DOCKERHUB_USER }}

--- a/.github/workflows/push-master.yml
+++ b/.github/workflows/push-master.yml
@@ -13,4 +13,6 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Run CI
-      run: ./ci.sh latest ${{ secrets.DOCKERHUB_PASSWORD }} ${{ secrets.DOCKERHUB_USER }}
+      run: |
+        echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u ${{ secrets.DOCKERHUB_USER }} --password-stdin
+        ./ci.sh latest

--- a/.github/workflows/push-master.yml
+++ b/.github/workflows/push-master.yml
@@ -1,3 +1,5 @@
+name: Build images and push master commits or on schedule
+
 on:
   push:
     branches:
@@ -5,36 +7,10 @@ on:
   schedule:
     - cron:  '0 6 * * 1-4'
 
-name: Build images
 jobs:
-  build:
+  push:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
     - name: Build and smoke-test a release candidate of the Docker image
-      run: |
-        # Create a backup of the image to allow rollback in case of failure
-        docker pull ppiper/jenkins-master:latest
-        docker tag ppiper/jenkins-master:latest ppiper/jenkins-master:backup-of-latest
-        # Build and test the image RC
-        docker build jenkins-master --tag ppiper/jenkins-master:RC
-        docker run --name cx-jenkins-master-test --detach --publish 8080:8080 \
-          -v /var/run/docker.sock:/var/run/docker.sock \
-          ppiper/jenkins-master:RC
-        # Wait up to 5 minutes for Jenkins to be up and fail if it does not return 200 after this time
-        docker exec cx-jenkins-master-test timeout 300 bash -c "until curl --fail http://localhost:8080/api/json; do sleep 5; done"
-        # Check for 'SEVERE' messages in Jenkins log (usually caused by plugin or configuration issues)
-        docker logs cx-jenkins-master-test 2> >(grep --quiet SEVERE)
-        # Print plugin config
-        docker exec cx-jenkins-master-test bash -c "curl http://localhost:8080/pluginManager/api/xml?depth=1"
-
-    - name: Print full log for good measure
-      run: docker logs cx-jenkins-master-test
-    - name: Push to Docker Hub (only on master branch)
-      if: github.ref == 'refs/heads/master'
-      run: |
-        docker tag ppiper/jenkins-master:RC ppiper/jenkins-master:latest
-        echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u ${{ secrets.DOCKERHUB_USER }} --password-stdin
-        docker push ppiper/jenkins-master:backup-of-latest
-        docker push ppiper/jenkins-master:latest
-        rm -f /home/runner/.docker/config.json
+      run: ./ci.sh latest  ${{ secrets.DOCKERHUB_PASSWORD }} ${{ secrets.DOCKERHUB_USER }}

--- a/.github/workflows/push-release.yml
+++ b/.github/workflows/push-release.yml
@@ -9,5 +9,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - name: Build and smoke-test a release candidate of the Docker image
+    - name: Build, test and push
       run: ./ci.sh ${GITHUB_REF##*/} ${{ secrets.DOCKERHUB_PASSWORD }} ${{ secrets.DOCKERHUB_USER }}

--- a/.github/workflows/push-release.yml
+++ b/.github/workflows/push-release.yml
@@ -9,5 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - name: Build, test and push
-      run: ./ci.sh ${GITHUB_REF##*/} ${{ secrets.DOCKERHUB_PASSWORD }} ${{ secrets.DOCKERHUB_USER }}
+      run: |
+        echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u ${{ secrets.DOCKERHUB_USER }} --password-stdin
+        ./ci.sh ${GITHUB_REF##*/}

--- a/.github/workflows/push-release.yml
+++ b/.github/workflows/push-release.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
+    - name: Build, test and push
       run: |
         echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u ${{ secrets.DOCKERHUB_USER }} --password-stdin
         ./ci.sh ${GITHUB_REF##*/}

--- a/.github/workflows/push-release.yml
+++ b/.github/workflows/push-release.yml
@@ -1,4 +1,4 @@
-name: Release new Release (tagged version)
+name: Release new Release (manual release)
 
 on:
   release:

--- a/.github/workflows/push-release.yml
+++ b/.github/workflows/push-release.yml
@@ -1,25 +1,13 @@
+name: Release new Release (tagged version)
+
 on:
   release:
     types: [published]
-name: Build images
+
 jobs:
-  build:
+  push:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
     - name: Build and smoke-test a release candidate of the Docker image
-      run: |
-        docker build jenkins-master --tag ppiper/jenkins-master:RC
-        docker run --name cx-jenkins-master-test --detach --publish 8080:8080 \
-          -v /var/run/docker.sock:/var/run/docker.sock \
-          ppiper/jenkins-master:RC
-        # Wait up to 5 minutes for Jenkins to be up and fail if it does not return 200 after this time
-        docker exec cx-jenkins-master-test timeout 300 bash -c "until curl --fail http://localhost:8080/api/json; do sleep 5; done"
-        # Check for 'SEVERE' messages in Jenkins log (usually caused by plugin or configuration issues)
-        docker logs cx-jenkins-master-test 2> >(grep --quiet SEVERE)
-    - name: Push to Docker Hub
-      run: |
-        docker tag ppiper/jenkins-master:RC ppiper/jenkins-master:${GITHUB_REF##*/}
-        echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u ${{ secrets.DOCKERHUB_USER }} --password-stdin
-        docker push ppiper/jenkins-master:${GITHUB_REF##*/}
-        rm -f /home/runner/.docker/config.json
+      run: ./ci.sh ${GITHUB_REF##*/} ${{ secrets.DOCKERHUB_PASSWORD }} ${{ secrets.DOCKERHUB_USER }}

--- a/.github/workflows/weekly-release.yml
+++ b/.github/workflows/weekly-release.yml
@@ -22,5 +22,5 @@ jobs:
           command: githubPublishRelease
           flags: --token ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and smoke-test a release candidate of the Docker image
+      - name: Build, test and push
         run: ./ci.sh ${PIPER_version} ${{ secrets.DOCKERHUB_PASSWORD }} ${{ secrets.DOCKERHUB_USER }}

--- a/.github/workflows/weekly-release.yml
+++ b/.github/workflows/weekly-release.yml
@@ -1,4 +1,4 @@
-name: Create new weekly Release
+name: Create new weekly Release (automated)
 
 on:
   schedule:

--- a/.github/workflows/weekly-release.yml
+++ b/.github/workflows/weekly-release.yml
@@ -1,0 +1,26 @@
+name: Create new weekly Release
+
+on:
+  schedule:
+    - cron:  '0 9 * * 1'
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Prepare Release
+        run: |
+          set -x
+          CURRENT_VERSION_LONG=$(curl --silent "https://api.github.com/repos/SAP/devops-docker-cx-server/releases/latest" | jq -r .tag_name)
+          CURRENT_VERSION=`echo $CURRENT_VERSION_LONG | cut -c 2-`
+          NEXT_VERSION=$(expr $CURRENT_VERSION + 1)
+          echo "::set-env name=PIPER_version::v$NEXT_VERSION"
+      - uses: SAP/project-piper-action@master
+        with:
+          piper-version: latest
+          command: githubPublishRelease
+          flags: --token ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and smoke-test a release candidate of the Docker image
+        run: ./ci.sh ${PIPER_version} ${{ secrets.DOCKERHUB_PASSWORD }} ${{ secrets.DOCKERHUB_USER }}

--- a/.github/workflows/weekly-release.yml
+++ b/.github/workflows/weekly-release.yml
@@ -23,4 +23,6 @@ jobs:
           flags: --token ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build, test and push
-        run: ./ci.sh ${PIPER_version} ${{ secrets.DOCKERHUB_PASSWORD }} ${{ secrets.DOCKERHUB_USER }}
+        run: |
+          echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u ${{ secrets.DOCKERHUB_USER }} --password-stdin
+          ./ci.sh ${PIPER_version}

--- a/.pipeline/config.yml
+++ b/.pipeline/config.yml
@@ -1,0 +1,4 @@
+steps:
+  githubPublishRelease:
+    owner: SAP
+    repository: devops-docker-cx-server

--- a/ci.sh
+++ b/ci.sh
@@ -1,10 +1,6 @@
 #!/bin/bash
-#set -o nounset
 set -o errexit
 
-set -x
-
-# valid values: latest or a tag v{N}
 VERSION=$1
 DOCKERHUB_USER=$2
 DOCKERHUB_PASSWORD=$3

--- a/ci.sh
+++ b/ci.sh
@@ -5,13 +5,13 @@ VERSION=$1
 DOCKERHUB_USER=$2
 DOCKERHUB_PASSWORD=$3
 
-echo ${DOCKERHUB_PASSWORD} | docker login -u ${DOCKERHUB_USER} --password-stdin
-
-
 if [[ ${VERSION} != latest ]] && [[ ${VERSION} != "v"* ]]; then
     echo "Error: Version must be 'latest' or 'v*'"
     exit 0
 fi
+
+echo Docker Registry info
+docker system info | grep -E 'Username|Registry'
 
 build_image() {
     local TAG=$1
@@ -63,16 +63,6 @@ smoke_test
 if [[ ${GITHUB_REF##*/} != master ]] && [[ ${GITHUB_REF##*/} != "v"* ]]; then
     echo "Not pushing on ref ${GITHUB_REF}"
     exit 0
-fi
-
-if [ -z ${DOCKERHUB_USER+x} ]; then
-    echo "DOCKERHUB_USER is unset, cannot push to Docker Hub";
-    exit 1
-fi
-
-if [ -z ${DOCKERHUB_PASSWORD+x} ]; then
-    echo "DOCKERHUB_PASSWORD is unset, cannot push to Docker Hub";
-    exit 1
 fi
 
 push_image ppiper/jenkins-master

--- a/ci.sh
+++ b/ci.sh
@@ -5,6 +5,9 @@ VERSION=$1
 DOCKERHUB_USER=$2
 DOCKERHUB_PASSWORD=$3
 
+echo ${DOCKERHUB_PASSWORD} | docker login -u ${DOCKERHUB_USER} --password-stdin
+
+
 if [[ ${VERSION} != latest ]] && [[ ${VERSION} != "v"* ]]; then
     echo "Error: Version must be 'latest' or 'v*'"
     exit 0
@@ -72,7 +75,6 @@ if [ -z ${DOCKERHUB_PASSWORD+x} ]; then
     exit 1
 fi
 
-echo ${DOCKERHUB_PASSWORD} | docker login -u ${DOCKERHUB_USER} --password-stdin
 push_image ppiper/jenkins-master
 push_image ppiper/jenkins-agent
 push_image ppiper/jenkins-agent-k8s

--- a/ci.sh
+++ b/ci.sh
@@ -1,9 +1,13 @@
 #!/bin/bash
 set -o errexit
+set -o nounset
+
+if [[ "$#" -ne 1 ]]; then
+	echo "Usage: $(basename "$0") (latest || v*)"
+	exit 1
+fi
 
 VERSION=$1
-DOCKERHUB_USER=$2
-DOCKERHUB_PASSWORD=$3
 
 if [[ ${VERSION} != latest ]] && [[ ${VERSION} != "v"* ]]; then
     echo "Error: Version must be 'latest' or 'v*'"
@@ -19,22 +23,23 @@ build_image() {
 
     if [ "x${VERSION}" = xlatest ]; then
         # Create a backup of the image to allow rollback in case of failure
-        docker pull ${TAG}:latest
-        docker tag ${TAG}:latest ${TAG}:backup-of-latest
+        docker pull "${TAG}":latest
+        docker tag "${TAG}":latest "${TAG}":backup-of-latest
     fi
 
     # Build the Release Candidate
-    docker build ${DIR} --tag ${TAG}:${VERSION}-RC
+    docker build "${DIR}" --tag "${TAG}":"${VERSION}"-RC
 }
 
 smoke_test() {
     # Test Jenkins master image
     docker run --name cx-jenkins-master-test --detach --publish 8080:8080 \
         -v /var/run/docker.sock:/var/run/docker.sock \
-        ppiper/jenkins-master:${VERSION}-RC
+        ppiper/jenkins-master:"${VERSION}"-RC
     # Wait up to 5 minutes for Jenkins to be up and fail if it does not return 200 after this time
     docker exec cx-jenkins-master-test timeout 300 bash -c "until curl --fail http://localhost:8080/api/json; do sleep 5; done"
-    # Check for 'SEVERE' messages in Jenkins log (usually caused by plugin or configuration issues)
+    # Check for 'SEVERE' messages in Jenkins log (usually caused by a plugin or configuration issues)
+    # Note: This will exit with code 1 if a finding of SEVERE exists
     docker logs cx-jenkins-master-test 2> >(grep --quiet SEVERE)
     # Print plugin config
     docker exec cx-jenkins-master-test bash -c "curl http://localhost:8080/pluginManager/api/xml?depth=1"
@@ -43,14 +48,13 @@ smoke_test() {
 push_image() {
     local TAG=$1
 
-    docker tag ${TAG}:${VERSION}-RC ${TAG}:${VERSION}
+    docker tag "${TAG}":"${VERSION}"-RC "${TAG}":"${VERSION}"
 
     if [ "x${VERSION}" = xlatest ]; then
-        echo docker push ${TAG}:backup-of-latest
+        docker push "${TAG}":backup-of-latest
     fi
 
-#fixme echos
-    echo docker push ${TAG}:${VERSION}
+    docker push "${TAG}":"${VERSION}"
 }
 
 build_image ppiper/jenkins-master jenkins-master

--- a/ci.sh
+++ b/ci.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+#set -o nounset
+set -o errexit
+
+set -x
+
+# valid values: latest or a tag v{N}
+VERSION=$1
+DOCKERHUB_USER=$2
+DOCKERHUB_PASSWORD=$3
+
+if [[ ${VERSION} != latest ]] && [[ ${VERSION} != "v"* ]]; then
+    echo "Error: Version must be 'latest' or 'v*'"
+    exit 0
+fi
+
+build_image() {
+    local TAG=$1
+    local DIR=$2
+
+    if [ "x${VERSION}" = xlatest ]; then
+        # Create a backup of the image to allow rollback in case of failure
+        docker pull ${TAG}:latest
+        docker tag ${TAG}:latest ${TAG}:backup-of-latest
+    fi
+
+    # Build the Release Candidate
+    docker build ${DIR} --tag ${TAG}:${VERSION}-RC
+}
+
+smoke_test() {
+    # Test Jenkins master image
+    docker run --name cx-jenkins-master-test --detach --publish 8080:8080 \
+        -v /var/run/docker.sock:/var/run/docker.sock \
+        ppiper/jenkins-master:${VERSION}-RC
+    # Wait up to 5 minutes for Jenkins to be up and fail if it does not return 200 after this time
+    docker exec cx-jenkins-master-test timeout 300 bash -c "until curl --fail http://localhost:8080/api/json; do sleep 5; done"
+    # Check for 'SEVERE' messages in Jenkins log (usually caused by plugin or configuration issues)
+    docker logs cx-jenkins-master-test 2> >(grep --quiet SEVERE)
+    # Print plugin config
+    docker exec cx-jenkins-master-test bash -c "curl http://localhost:8080/pluginManager/api/xml?depth=1"
+}
+
+push_image() {
+    local TAG=$1
+
+    docker tag ${TAG}:${VERSION}-RC ${TAG}:${VERSION}
+
+    if [ "x${VERSION}" = xlatest ]; then
+        echo docker push ${TAG}:backup-of-latest
+    fi
+
+#fixme echos
+    echo docker push ${TAG}:${VERSION}
+}
+
+build_image ppiper/jenkins-master jenkins-master
+build_image ppiper/jenkins-agent jenkins-agent
+build_image ppiper/jenkins-agent-k8s jenkins-agent-k8s
+build_image ppiper/cx-server-companion cx-server-companion
+
+smoke_test
+
+if [[ ${GITHUB_REF##*/} != master ]] && [[ ${GITHUB_REF##*/} != "v"* ]]; then
+    echo "Not pushing on ref ${GITHUB_REF}"
+    exit 0
+fi
+
+if [ -z ${DOCKERHUB_USER+x} ]; then
+    echo "DOCKERHUB_USER is unset, cannot push to Docker Hub";
+    exit 1
+fi
+
+if [ -z ${DOCKERHUB_PASSWORD+x} ]; then
+    echo "DOCKERHUB_PASSWORD is unset, cannot push to Docker Hub";
+    exit 1
+fi
+
+echo ${DOCKERHUB_PASSWORD} | docker login -u ${DOCKERHUB_USER} --password-stdin
+push_image ppiper/jenkins-master
+push_image ppiper/jenkins-agent
+push_image ppiper/jenkins-agent-k8s
+push_image ppiper/cx-server-companion


### PR DESCRIPTION
The purpose of this PR is to provide updated Docker images on a regular basis, both for latest as for releases. This will also get rid of the (in my experience) unreliable autobuilds on Docker hub.

The idea is to week-daily push new latest images, and once a week to an automated release. This way, the users are not forced to use outdated software versions when using the images.

Todo before merge:

- [x] Disable auto-builds on docker hub