### PR TITLE
Add runtime image for act

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -56,6 +56,7 @@ build_image ppiper/jenkins-master jenkins-master
 build_image ppiper/jenkins-agent jenkins-agent
 build_image ppiper/jenkins-agent-k8s jenkins-agent-k8s
 build_image ppiper/cx-server-companion cx-server-companion
+build_image ppiper/action-runtime project-piper-action-runtime
 
 smoke_test
 
@@ -68,3 +69,4 @@ push_image ppiper/jenkins-master
 push_image ppiper/jenkins-agent
 push_image ppiper/jenkins-agent-k8s
 push_image ppiper/cx-server-companion
+build_image ppiper/action-runtime

--- a/project-piper-action-runtime/Dockerfile
+++ b/project-piper-action-runtime/Dockerfile
@@ -21,10 +21,10 @@ ARG JVM_VERSION
 ARG MAVEN_VERSION
 ARG NODE_VERSION
 
-ENV PATH=/opt/apache-maven-$MAVEN_VERSION/bin:/opt/node-$NODE_VERSION-linux-x64/bin:/opt/sapmachine-jdk-$JVM_VERSION/bin:$PATH
-
 # hadolint ignore=DL3008,DL3015
-RUN apt-get -y update; apt-get -y dist-upgrade; apt-get -y install wget curl unzip \
+RUN apt-get -y update \
+ && apt-get -y dist-upgrade \
+ && apt-get -y --no-install-recommends install wget curl ca-certificates unzip \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /opt /opt
@@ -32,3 +32,6 @@ RUN mkdir -p /home/actions && echo "actions:x:1000:1000:actions:/home/actions:/b
 RUN chown -R actions /home/actions
 RUN echo "PATH=/opt/apache-maven-$MAVEN_VERSION/bin:/opt/node-$NODE_VERSION-linux-x64/bin:/opt/sapmachine-jdk-$JVM_VERSION/bin:$PATH" >> /home/actions/.bashrc
 WORKDIR /home/actions
+
+ENV PATH=/opt/apache-maven-$MAVEN_VERSION/bin:/opt/node-$NODE_VERSION-linux-x64/bin:/opt/sapmachine-jdk-$JVM_VERSION/bin:$PATH
+ENV RUNNER_TEMP=/tmp

--- a/project-piper-action-runtime/Dockerfile
+++ b/project-piper-action-runtime/Dockerfile
@@ -21,17 +21,19 @@ ARG JVM_VERSION
 ARG MAVEN_VERSION
 ARG NODE_VERSION
 
-# hadolint ignore=DL3008,DL3015
+# hadolint ignore=DL3008
 RUN apt-get -y update \
  && apt-get -y dist-upgrade \
  && apt-get -y --no-install-recommends install wget curl ca-certificates unzip \
  && apt-get clean \
- && rm -rf /var/lib/apt/lists/*
-COPY --from=builder /opt /opt
-RUN mkdir -p /home/actions && echo "actions:x:1000:1000:actions:/home/actions:/bin/bash" >> /etc/passwd
-RUN chown -R actions /home/actions
-RUN echo "PATH=/opt/apache-maven-$MAVEN_VERSION/bin:/opt/node-$NODE_VERSION-linux-x64/bin:/opt/sapmachine-jdk-$JVM_VERSION/bin:$PATH" >> /home/actions/.bashrc
+ && rm -rf /var/lib/apt/lists/* \
+ && mkdir -p /home/actions && echo "actions:x:1000:1000:actions:/home/actions:/bin/bash" >> /etc/passwd \
+ && chown -R actions /home/actions \
+ && echo "PATH=/opt/apache-maven-$MAVEN_VERSION/bin:/opt/node-$NODE_VERSION-linux-x64/bin:/opt/sapmachine-jdk-$JVM_VERSION/bin:$PATH" >> /home/actions/.bashrc
+
 WORKDIR /home/actions
 
 ENV PATH=/opt/apache-maven-$MAVEN_VERSION/bin:/opt/node-$NODE_VERSION-linux-x64/bin:/opt/sapmachine-jdk-$JVM_VERSION/bin:$PATH
 ENV RUNNER_TEMP=/tmp
+
+COPY --from=builder /opt /opt

--- a/project-piper-action-runtime/Dockerfile
+++ b/project-piper-action-runtime/Dockerfile
@@ -1,0 +1,31 @@
+ARG JVM_VERSION=11.0.7
+ARG MAVEN_VERSION=3.6.3
+ARG NODE_VERSION=v12.16.2
+
+FROM debian:buster-slim as builder
+
+ARG JVM_VERSION
+ARG MAVEN_VERSION
+ARG NODE_VERSION
+
+ADD https://github.com/SAP/SapMachine/releases/download/sapmachine-${JVM_VERSION}/sapmachine-jdk-${JVM_VERSION}_linux-x64_bin.tar.gz /jdk.tgz
+RUN tar xzf jdk.tgz -C /opt
+ADD http://apache.lauf-forum.at/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz /maven.tgz
+RUN tar xzf /maven.tgz -C /opt
+ADD https://nodejs.org/dist/${NODE_VERSION}/node-${NODE_VERSION}-linux-x64.tar.gz /node.tgz
+RUN tar xzf /node.tgz -C /opt
+
+FROM debian:buster-slim
+
+ARG JVM_VERSION
+ARG MAVEN_VERSION
+ARG NODE_VERSION
+
+ENV PATH=/opt/apache-maven-$MAVEN_VERSION/bin:/opt/node-$NODE_VERSION-linux-x64/bin:/opt/sapmachine-jdk-$JVM_VERSION/bin:$PATH
+
+RUN apt-get -y update; apt-get -y dist-upgrade; apt-get -y install wget curl unzip
+COPY --from=builder /opt /opt
+RUN mkdir -p /home/actions && echo "actions:x:1000:1000:actions:/home/actions:/bin/bash" >> /etc/passwd
+RUN chown -R actions /home/actions
+RUN echo "PATH=/opt/apache-maven-$MAVEN_VERSION/bin:/opt/node-$NODE_VERSION-linux-x64/bin:/opt/sapmachine-jdk-$JVM_VERSION/bin:$PATH" >> /home/actions/.bashrc
+WORKDIR /home/actions

--- a/project-piper-action-runtime/Dockerfile
+++ b/project-piper-action-runtime/Dockerfile
@@ -23,7 +23,10 @@ ARG NODE_VERSION
 
 ENV PATH=/opt/apache-maven-$MAVEN_VERSION/bin:/opt/node-$NODE_VERSION-linux-x64/bin:/opt/sapmachine-jdk-$JVM_VERSION/bin:$PATH
 
-RUN apt-get -y update; apt-get -y dist-upgrade; apt-get -y install wget curl unzip
+# hadolint ignore=DL3008,DL3015
+RUN apt-get -y update; apt-get -y dist-upgrade; apt-get -y install wget curl unzip \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /opt /opt
 RUN mkdir -p /home/actions && echo "actions:x:1000:1000:actions:/home/actions:/bin/bash" >> /etc/passwd
 RUN chown -R actions /home/actions

--- a/project-piper-action-runtime/README.md
+++ b/project-piper-action-runtime/README.md
@@ -1,0 +1,40 @@
+# Project "Piper" GitHub Actions Runtime Environment
+
+Dockerfile for running the [Project "Piper" Action](https://github.com/SAP/project-piper-action) locally using [act](https://github.com/nektos/act)
+
+**NOTE:** This is a Proof of Concept, depending on what your GitHub Actions workflow does, the image will be not work.
+The image tries to mirror [GitHub's hosted runner image](https://github.com/actions/virtual-environments/blob/master/images/linux/Ubuntu1804-README.md) to a very limited scope.
+The goal is to provide an environment capable of running workflows based on project "Piper", not more.
+It contains a user called `actions` with uid `1000`.
+Additonally, it includes a JDK, Maven and NodeJs.
+Extend the Dockerfile as you see fit and build your own image.
+
+## Usage
+
+* Install Docker Desktop, if you don't have already
+* Install act from https://github.com/nektos/act
+* Build the image: `docker build -t myruntime .`
+* Run using: `act -P ubuntu-18.04=myruntime` in the root of your project with a project "Piper"-based workflow
+
+The version of the provided JDK, Maven and NodeJs may be modified using [build arguments](https://docs.docker.com/engine/reference/commandline/build/#set-build-time-variables---build-arg).
+As an example, using another NodeJs version can be done using `docker build --build-arg=NODE_VERSION=v13.0.0 -t myruntime .`.
+
+Available arguments:
+
+- `JVM_VERSION`
+- `MAVEN_VERSION`
+- `NODE_VERSION`
+
+## License
+
+Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved.
+This file is licensed under the Apache Software License, v. 2 except as noted
+otherwise in the [LICENSE file](https://github.com/SAP/devops-docker-cx-server/blob/master/LICENSE).
+
+Please note that Docker images can contain other software which may be licensed under different licenses. This License file is also included in the Docker image. For any usage of built Docker images please make sure to check the licenses of the artifacts contained in the images.
+
+Amongst others, this image includes:
+
+- [SapMachine](https://sap.github.io/SapMachine/)
+- [Maven](http://maven.apache.org/)
+- [Node.js](https://nodejs.org/en/)

--- a/project-piper-action-runtime/README.md
+++ b/project-piper-action-runtime/README.md
@@ -2,7 +2,7 @@
 
 Dockerfile for running the [Project "Piper" Action](https://github.com/SAP/project-piper-action) locally using [act](https://github.com/nektos/act)
 
-**NOTE:** This is a Proof of Concept, depending on what your GitHub Actions workflow does, the image will be not work.
+**NOTE:** This is a Proof of Concept, depending on what your GitHub Actions workflow does, the image will not work out of the box.
 The image tries to mirror [GitHub's hosted runner image](https://github.com/actions/virtual-environments/blob/master/images/linux/Ubuntu1804-README.md) to a very limited scope.
 The goal is to provide an environment capable of running workflows based on project "Piper", not more.
 It contains a user called `actions` with uid `1000`.


### PR DESCRIPTION
Dockerfile for running the [Project "Piper" Action](https://github.com/SAP/project-piper-action) locally using [act](https://github.com/nektos/act)

**NOTE:** This is a Proof of Concept, depending on what your GitHub Actions workflow does, the image will not work out of the box.
The image tries to mirror [GitHub's hosted runner image](https://github.com/actions/virtual-environments/blob/master/images/linux/Ubuntu1804-README.md) to a very limited scope.
The goal is to provide an environment capable of running workflows based on project "Piper", not more.
It contains a user called `actions` with uid `1000`.
Additonally, it includes a JDK, Maven and NodeJs.
Extend the Dockerfile as you see fit and build your own image.
