### PR TITLE
Fix release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,12 +13,17 @@ jobs:
       - uses: actions/checkout@v1
       - name: Prepare Release
         run: |
-          CURRENT_VERSION_LONG=$(curl --silent "https://api.github.com/repos/SAP/devops-docker-cx-server/releases/latest" | jq -r .tag_name)
+          CURRENT_VERSION_LONG=$(curl --silent "https://api.github.com/repos/SAP/devops-docker-cx-server/releases" | jq -r '.[].tag_name' | head -n1)
           echo Current version: $CURRENT_VERSION_LONG
           CURRENT_VERSION=`echo $CURRENT_VERSION_LONG | cut -c 2- | cut -d. -f1`
-          NEXT_VERSION=$(expr $CURRENT_VERSION + 1)
-          echo Next version: v$NEXT_VERSION
-          echo "::set-env name=PIPER_version::v$NEXT_VERSION"
+          NEXT_VERSION=v$(expr $CURRENT_VERSION + 1)
+          echo Next version: $NEXT_VERSION
+          STATUS_CODE_FOR_NEXT_RELEASE=$(curl -s -o /dev/null -w "%{http_code}" "https://api.github.com/repos/SAP/devops-docker-cx-server/releases/tags/$NEXT_VERSION")
+          if [ "$STATUS_CODE_FOR_NEXT_RELEASE" != "404" ]; then
+            echo "Planned next release version ($NEXT_VERSION) already exists, aborting process"
+            exit 1
+          fi
+          echo "::set-env name=PIPER_version::$NEXT_VERSION"
       - uses: SAP/project-piper-action@master
         with:
           piper-version: latest


### PR DESCRIPTION
Currently the release process is broken because the GitHub api does not handle "get latest release" well if multiple tags point to the same commit, cf api docs https://developer.github.com/v3/repos/releases/#get-the-latest-release

Quote: 

> The latest release is the most recent non-prerelease, non-draft release, sorted by the created_at attribute. The created_at attribute is the date of the commit used for the release, and not the date when the release was drafted or published.

So if both `v10` and `v11` point to the same commit, `v10` is returned which breaks our process because it tries to release `v11` again. Still it makes sense to do those releases to rebuild the docker images and get the security updates in the base images.

The new way is to get the list of releases and manually "take the latest" which assumes the list is sorted (which it seems to be, but maybe that is also a false assumption). Additional sorting might be required, if this turns out to be an issue.