### PR TITLE
Fix Release Workflow, Remove defunct configuration-as-code-support plugin

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,13 +24,14 @@ jobs:
             exit 1
           fi
           echo "::set-env name=PIPER_version::$NEXT_VERSION"
-      - uses: SAP/project-piper-action@master
-        with:
-          piper-version: latest
-          command: githubPublishRelease
-          flags: --token ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build, test and push
         run: |
           echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u ${{ secrets.DOCKERHUB_USER }} --password-stdin
           ./ci.sh ${PIPER_version}
+
+      - uses: SAP/project-piper-action@master
+        with:
+          piper-version: latest
+          command: githubPublishRelease
+          flags: --token ${{ secrets.GITHUB_TOKEN }}

--- a/ci.sh
+++ b/ci.sh
@@ -52,21 +52,30 @@ push_image() {
     docker push "${TAG}":"${VERSION}"
 }
 
+echo '::group::Build Jenkins Master Image'
 build_image ppiper/jenkins-master jenkins-master
+echo '::endgroup'
+
+echo '::group::Build other Images'
 build_image ppiper/jenkins-agent jenkins-agent
 build_image ppiper/jenkins-agent-k8s jenkins-agent-k8s
 build_image ppiper/cx-server-companion cx-server-companion
 build_image ppiper/action-runtime project-piper-action-runtime
+echo '::endgroup'
 
+echo '::group::Smoketest'
 smoke_test
+echo '::endgroup'
 
 if [[ ${GITHUB_REF##*/} != master ]] && [[ ${GITHUB_REF##*/} != "v"* ]]; then
     echo "Not pushing on ref ${GITHUB_REF}"
     exit 0
 fi
 
+echo '::group::Push Images'
 push_image ppiper/jenkins-master
 push_image ppiper/jenkins-agent
 push_image ppiper/jenkins-agent-k8s
 push_image ppiper/cx-server-companion
 push_image ppiper/action-runtime
+echo '::endgroup'

--- a/ci.sh
+++ b/ci.sh
@@ -52,6 +52,14 @@ push_image() {
     docker push "${TAG}":"${VERSION}"
 }
 
+echo '::group::Pull Base Images'
+docker pull jenkins/jenkins:lts-slim
+docker pull node:11-alpine
+docker pull openjdk:8-jre-slim
+docker pull jenkins/jnlp-slave:3.27-1-alpine
+docker pull debian:buster-slim
+echo '::endgroup'
+
 echo '::group::Build Jenkins Master Image'
 build_image ppiper/jenkins-master jenkins-master
 echo '::endgroup'

--- a/jenkins-master/plugins.txt
+++ b/jenkins-master/plugins.txt
@@ -9,7 +9,6 @@ checkmarx
 cobertura
 command-launcher
 configuration-as-code
-configuration-as-code-support
 credentials
 credentials-binding
 cucumber-testresult-plugin


### PR DESCRIPTION
- Reorder workflow so that the release is only created if the images could be built and pushed before
- Use "groups" to make it easier to read the output of the GitHub Actions workflow
- Remove non-existing `configuration-as-code-support` plugin