### PR TITLE
Enable push to GitHub Container Registry

### DIFF
--- a/.github/workflows/latest.yml
+++ b/.github/workflows/latest.yml
@@ -15,5 +15,5 @@ jobs:
     - name: Run CI
       run: |
         echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u ${{ secrets.DOCKERHUB_USER }} --password-stdin
-        echo "${{ secrets.GITHUB_REGISTRY_PAT }}" | docker login https://ghcr.io -u ${{ secrets.GITHUB_REGISTRY_USER }} --password-stdin
+        echo "${{ secrets.CR_PAT }}" | docker login https://ghcr.io -u ${{ secrets.CR_USER }} --password-stdin
         ./ci.sh latest

--- a/.github/workflows/latest.yml
+++ b/.github/workflows/latest.yml
@@ -15,4 +15,5 @@ jobs:
     - name: Run CI
       run: |
         echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u ${{ secrets.DOCKERHUB_USER }} --password-stdin
+        echo "${{ secrets.GITHUB_REGISTRY_PAT }}" | docker login https://ghcr.io -u ${{ secrets.GITHUB_REGISTRY_USER }} --password-stdin
         ./ci.sh latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Build, test and push
         run: |
-          echo "${{ secrets.GITHUB_REGISTRY_PAT }}" | docker login https://ghcr.io -u ${{ secrets.GITHUB_REGISTRY_USER }} --password-stdin
+          echo "${{ secrets.CR_PAT }}" | docker login https://ghcr.io -u ${{ secrets.CR_USER }} --password-stdin
           echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u ${{ secrets.DOCKERHUB_USER }} --password-stdin
           ./ci.sh ${PIPER_version}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,7 @@ jobs:
 
       - name: Build, test and push
         run: |
+          echo "${{ secrets.GITHUB_REGISTRY_PAT }}" | docker login https://ghcr.io -u ${{ secrets.GITHUB_REGISTRY_USER }} --password-stdin
           echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u ${{ secrets.DOCKERHUB_USER }} --password-stdin
           ./ci.sh ${PIPER_version}
 

--- a/ci.sh
+++ b/ci.sh
@@ -17,6 +17,9 @@ fi
 build_image() {
     local TAG=$1
     local DIR=$2
+    # Replace slash with dash for GitHub because "sap" is already the org and "ppiper" is a part of the name
+    local GH_TAG=$(echo $TAG | sed -e 's/\//-/g') #fixme just testing
+
 
     if [ "${VERSION}" = latest ]; then
         # Create a backup of the image to allow rollback in case of failure
@@ -26,6 +29,7 @@ build_image() {
 
     # Build the Release Candidate
     docker build "${DIR}" --tag "${TAG}":"${VERSION}"-RC
+    docker tag "${TAG}":"${VERSION}"-RC "ghcr.io/sap/${GH_TAG}":"${VERSION}" #fixme just testing
 }
 
 smoke_test() {
@@ -42,16 +46,18 @@ smoke_test() {
 
 push_image() {
     local TAG=$1
+    # Replace slash with dash for GitHub because "sap" is already the org and "ppiper" is a part of the name
+    local GH_TAG=$(echo $TAG | sed -e 's/\//-/g')
 
     docker tag "${TAG}":"${VERSION}"-RC "${TAG}":"${VERSION}"
-    docker tag "${TAG}":"${VERSION}"-RC "ghcr.io/sap/${TAG}":"${VERSION}"
+    docker tag "${TAG}":"${VERSION}"-RC "ghcr.io/sap/${GH_TAG}":"${VERSION}"
 
     if [ "${VERSION}" = latest ]; then
         docker push "${TAG}":backup-of-latest
     fi
 
     docker push "${TAG}":"${VERSION}"
-    docker push "ghcr.io/sap/${TAG}":"${VERSION}"
+    docker push "ghcr.io/sap/${GH_TAG}":"${VERSION}"
 }
 
 echo '::group::Pull Base Images'

--- a/ci.sh
+++ b/ci.sh
@@ -44,12 +44,14 @@ push_image() {
     local TAG=$1
 
     docker tag "${TAG}":"${VERSION}"-RC "${TAG}":"${VERSION}"
+    docker tag "${TAG}":"${VERSION}"-RC "ghcr.io/SAP/${TAG}":"${VERSION}"
 
     if [ "${VERSION}" = latest ]; then
         docker push "${TAG}":backup-of-latest
     fi
 
     docker push "${TAG}":"${VERSION}"
+    docker push "ghcr.io/SAP/${TAG}":"${VERSION}"
 }
 
 echo '::group::Pull Base Images'

--- a/ci.sh
+++ b/ci.sh
@@ -44,14 +44,14 @@ push_image() {
     local TAG=$1
 
     docker tag "${TAG}":"${VERSION}"-RC "${TAG}":"${VERSION}"
-    docker tag "${TAG}":"${VERSION}"-RC "ghcr.io/SAP/${TAG}":"${VERSION}"
+    docker tag "${TAG}":"${VERSION}"-RC "ghcr.io/sap/${TAG}":"${VERSION}"
 
     if [ "${VERSION}" = latest ]; then
         docker push "${TAG}":backup-of-latest
     fi
 
     docker push "${TAG}":"${VERSION}"
-    docker push "ghcr.io/SAP/${TAG}":"${VERSION}"
+    docker push "ghcr.io/sap/${TAG}":"${VERSION}"
 }
 
 echo '::group::Pull Base Images'

--- a/ci.sh
+++ b/ci.sh
@@ -17,9 +17,6 @@ fi
 build_image() {
     local TAG=$1
     local DIR=$2
-    # Replace slash with dash for GitHub because "sap" is already the org and "ppiper" is a part of the name
-    local GH_TAG=$(echo $TAG | sed -e 's/\//-/g') #fixme just testing
-
 
     if [ "${VERSION}" = latest ]; then
         # Create a backup of the image to allow rollback in case of failure
@@ -29,7 +26,6 @@ build_image() {
 
     # Build the Release Candidate
     docker build "${DIR}" --tag "${TAG}":"${VERSION}"-RC
-    docker tag "${TAG}":"${VERSION}"-RC "ghcr.io/sap/${GH_TAG}":"${VERSION}" #fixme just testing
 }
 
 smoke_test() {


### PR DESCRIPTION
In order to provide an alternative for users when Docker hub introduces rate limiting, we chose to also push the images to GitHub. This PR enables it for the images in this repo.