### PR TITLE
Remove not available plugins

### DIFF
--- a/jenkins-master/plugins.txt
+++ b/jenkins-master/plugins.txt
@@ -1,4 +1,3 @@
-analysis-collector
 ansicolor
 authorize-project
 badge
@@ -14,7 +13,6 @@ credentials-binding
 cucumber-testresult-plugin
 docker-workflow
 email-ext
-findbugs
 gatling
 ghprb
 github-branch-source
@@ -36,7 +34,6 @@ pipeline-input-step
 pipeline-milestone-step
 pipeline-stage-step
 pipeline-utility-steps
-pmd
 rebuild
 role-strategy
 saferestart


### PR DESCRIPTION
**WARNING**: This will break Jenkins pipelines that depend on any of those pipelines for new Cx Server instances.
Merge after we checked our ready-made pipelines.

Following plugins can't be downloaded anymore:

- analysis-collector
- findbugs
- pmd

Warnings ng should be used instead https://plugins.jenkins.io/warnings-ng/

