### PR TITLE
Disable timers until #95 is merged

### DIFF
--- a/.github/workflows/latest.yml
+++ b/.github/workflows/latest.yml
@@ -1,11 +1,9 @@
-name: Build images and push (on master branch or on schedule)
+name: Build images and push
 
 on:
   push:
     branches:
       - "**"
-  schedule:
-    - cron:  '0 6 * * 1-4'
 
 jobs:
   push:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,6 @@ name: Create new weekly Release (automated)
 on:
   repository_dispatch:
     types: perform-release
-  schedule:
-    - cron:  '0 9 * * 1'
 
 jobs:
   create-release:


### PR DESCRIPTION
All scheduled builds fail currently, so disable them until we can build again. To be reverted after #95 is merged