### PR TITLE
jenkins-master: Fix URL to "Operations Guide"

### DIFF
--- a/jenkins-master/README.md
+++ b/jenkins-master/README.md
@@ -3,7 +3,7 @@
 Jenkins master image for use with project ["Piper"](https://github.com/SAP/jenkins-library).
 
 This image is intended to be used with the Cx Server life-cycle management.
-Please refer to the [Operations Guide for Cx Server](https://github.com/SAP/devops-docker-images/blob/master/docs/operations/cx-server-operations-guide.md) for detailed usage.
+Please refer to the [Operations Guide for Cx Server](../docs/operations/cx-server-operations-guide.md) for detailed usage.
 
 ## Download
 


### PR DESCRIPTION
This commit fixes the URL to the "Operations Guide for Cx Server"

The correct URL is: https://github.com/SAP/devops-docker-cx-server/blob/master/docs/operations/cx-server-operations-guide.md
Instead of an absolute URL, a relative can be used as well, which this commit does.